### PR TITLE
Add action to upload to GitHub Pages

### DIFF
--- a/.github/workflows/mdbook-to-github-pages.yml
+++ b/.github/workflows/mdbook-to-github-pages.yml
@@ -41,21 +41,9 @@ jobs:
           CARGO_TARGET_DIR: /tmp/target
 
       - name: Deploy to GitHub Pages
-        run: |
-          # Use `github-actions[bot]`'s actual email address and name to
-          # attribute the commit to it. The number in the email address is the
-          # bot's GitHub ID.
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-
-          cd /tmp/book
-
-          touch .nojekyll
-          echo ${{ inputs.cname }} > CNAME
-
-          git init .
-          git add .
-          git commit -m "deploy to github pages"
-          git branch -m gh-pages
-          git push --force https://github-actions:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
+        uses: ferrous-systems/shared-github-actions/github-pages@main
+        with:
+          path: /tmp/book
+          cname: ${{ inputs.cname }}
+          token: ${{ secrets.GITHUB_TOKEN }}
         if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -45,6 +45,32 @@ steps:
       target-dir: path/to/target/
 ```
 
+## Upload to GitHub Pages
+
+An action is present in this repository to upload the contents of a directory
+to GitHub Pages. The action requires the path that should be uploaded. It will
+disable Jekyll pre-processing, it will create a commit with the contents you
+want to upload and it will push it to the `gh-pages` branch:
+
+```yaml
+steps:
+  - uses: ferrous-systems/shared-github-actions/github-pages@main
+    with:
+      path: build/site/
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+A domain name can be optionally specified:
+
+```yaml
+steps:
+  - uses: ferrous-systems/shared-github-actions/github-pages@main
+    with:
+      path: build/site/
+      cname: subdomain.example.com
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ## Authenticate with AWS
 
 An action is present in this repository to authenticate with an AWS account and

--- a/github-pages/action.yml
+++ b/github-pages/action.yml
@@ -1,0 +1,46 @@
+name: Upload to GitHub Pages
+description: Upload the contents of a directory to GitHub Pages
+
+inputs:
+  path:
+    type: string
+    description: Path of the directory to upload to GitHub Pages
+    required: true
+  cname:
+    type: string
+    default: ""
+  token:
+    type: string
+    description: GitHub token used to push the gh-pages branch
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Disable Jekyll preprocessing
+      run: touch "${{ inputs.path }}/.nojekyll"
+      shell: bash
+
+    - name: Set the CNAME
+      run: echo "${{ inputs.cname }}" >> "${{ inputs.path }}/CNAME"
+      shell: bash
+      if: inputs.cname != ''
+
+    - name: Upload to GitHub Pages
+      run: |
+        cd "${{ inputs.path }}"
+
+        rm -rf .git
+        git init .
+
+        # Use `github-actions[bot]`'s actual email address and name to
+        # attribute the commit to it. The number in the email address is the
+        # bot's GitHub ID.
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+
+        git add .
+        git commit -m "deploy to github pages"
+        git branch -m gh-pages
+        git push --force https://github-actions:${{ inputs.token }}@github.com/${{ github.repository }} gh-pages
+      shell: bash


### PR DESCRIPTION
This was extracted from the mdbook-to-github-pages workflow so that it can be reused for repositories not relying on mdBook.