### PR TITLE
Fix deprecation warnings in `cache-rust`

### DIFF
--- a/cache-rust/action.yml
+++ b/cache-rust/action.yml
@@ -11,11 +11,11 @@ runs:
   steps:
     - name: Detect the installed Rust version
       id: rustc
-      run: echo "::set-output name=version::$(rustc -V)"
+      run: echo "version=$(rustc -V)" >> "${GITHUB_OUTPUT}"
       shell: bash
 
     - name: Cache Cargo's registry cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cargo/registry/cache
         key: cargo-registry-cache-${{ hashFiles('**/Cargo.lock') }}
@@ -23,7 +23,7 @@ runs:
           cargo-registry-cache-
 
     - name: Cache Cargo's registry index
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cargo/registry/index
         key: cargo-registry-index-${{ hashFiles('**/Cargo.lock') }}
@@ -31,7 +31,7 @@ runs:
           cargo-registry-index-
 
     - name: Cache Cargo's target directory
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: "${{ inputs.target-dir }}"
         key: cargo-build-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
This PR fixes the following deprecation warnings in the `cache-rust` action:

* [Deprecated `::set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
* NodeJS 12 deprecation in `actions/cache`

Tested this on an internal repository and it still works.