### PR TITLE
Allow setting a different cache key for separate jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ steps:
       target-dir: path/to/target/
 ```
 
+If you're using the action in multiple jobs in the same repository, you should
+specify an unique cache key for each job:
+
+```yaml
+steps:
+  - uses: ferrous-systems/shared-github-actions/cache-rust@main
+    with:
+      cache-key: job1
+```
+
 ## Upload to GitHub Pages
 
 An action is present in this repository to upload the contents of a directory

--- a/cache-rust/action.yml
+++ b/cache-rust/action.yml
@@ -5,6 +5,9 @@ inputs:
   target-dir:
     description: Path to the Cargo target directory
     default: target/
+  cache-key:
+    description: Cache key to distinguish this invocation from other uses of the action in the same repo
+    default: default
 
 runs:
   using: composite
@@ -18,22 +21,22 @@ runs:
       uses: actions/cache@v3
       with:
         path: ~/.cargo/registry/cache
-        key: cargo-registry-cache-${{ hashFiles('**/Cargo.lock') }}
+        key: cargo-registry-cache-${{ inputs.cache-key }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          cargo-registry-cache-
+          cargo-registry-cache-${{ inputs.cache-key }}-
 
     - name: Cache Cargo's registry index
       uses: actions/cache@v3
       with:
         path: ~/.cargo/registry/index
-        key: cargo-registry-index-${{ hashFiles('**/Cargo.lock') }}
+        key: cargo-registry-index-${{ inputs.cache-key }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          cargo-registry-index-
+          cargo-registry-index-${{ inputs.cache-key }}-
 
     - name: Cache Cargo's target directory
       uses: actions/cache@v3
       with:
-        path: "${{ inputs.target-dir }}"
-        key: cargo-build-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
+        path: "${{ inputs.target-dir }}-${{ inputs.cache-key }}-"
+        key: cargo-build-${{ inputs.cache-key }}-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          cargo-build-${{ steps.rustc.outputs.version }}-
+          cargo-build-${{ inputs.cache-key }}-${{ steps.rustc.outputs.version }}-


### PR DESCRIPTION
This allows using the cache action in separate jobs in the same repository without sharing caches.